### PR TITLE
Switch to SESH ticker

### DIFF
--- a/observer.py
+++ b/observer.py
@@ -135,9 +135,9 @@ def format_si(value):
     return filter_round(value) + '{}'.format(si_suffix[i])
 
 @app.template_filter('cash')
-def format_oxen(atomic, tag_name='', tag=True, fixed=False, decimals=9, zero=None, formatted=False):
+def format_oxen(atomic, tag_name='SESH', tag=True, fixed=False, decimals=9, zero=None, formatted=False):
     """Formats an atomic current value as a human currency value.
-    tag - if False then don't append " OXEN"
+    tag - if False then don't append "<tag_name>"
     fixed - if True then don't strip insignificant trailing 0's and '.'
     decimals - at how many decimal we should round; the default is full precision
     fixed - if specified, replace 0 with this string
@@ -155,9 +155,6 @@ def format_oxen(atomic, tag_name='', tag=True, fixed=False, decimals=9, zero=Non
             disp = disp.rstrip('0').rstrip('.')
 
     if tag:
-        if tag_name == 'OXEN':
-            tag_name = ''
-
         disp += ' ' + tag_name
     return disp
 

--- a/templates/include/tx_type_symbol.html
+++ b/templates/include/tx_type_symbol.html
@@ -43,7 +43,7 @@
                              {%-endif%}
                              {{tx.extra.service_node_pubkey}}
                              {%-for c in tx.extra.contributors%}
-                             {{c.address | truncate(15)}} ({{(c.amount / 1000000000) | chop0}} Network Token stake)
+                             {{c.address | truncate(15)}} ({{(c.amount / 1000000000) | chop0 | cash }} stake)
                              {%-endfor%}">🏁{%if text%} registration{%endif%}</span>
             {% endif %}
         {%- elif 'sn_contributor' in tx.extra -%}

--- a/templates/index.html
+++ b/templates/index.html
@@ -60,14 +60,14 @@
                 {% if not arbitrum_info or 'balance_reward_rate_pool' not in arbitrum_info %}
                     (loading...)
                 {% else %}
-                    {{arbitrum_info.balance_reward_rate_pool | cash(tag_name='Network Token', decimals=2, formatted=True)}}
+                    {{arbitrum_info.balance_reward_rate_pool | cash(decimals=2, formatted=True)}}
                 {%endif%}
             </span>
             <span><label>Session Node Rewards balance</label>{{ components.tooltip("Arbitrum data is currently sourced from the Session Testnet.") }}:
                 {% if not arbitrum_info or 'balance_service_node_rewards' not in arbitrum_info %}
                     (loading...)
                 {% else %}
-                    {{arbitrum_info.balance_service_node_rewards | cash(tag_name='Network Token', decimals=2, formatted=True)}}
+                    {{arbitrum_info.balance_service_node_rewards | cash(decimals=2, formatted=True)}}
                 {%endif%}
             </span>
         </h4>

--- a/templates/staking_info.html
+++ b/templates/staking_info.html
@@ -7,7 +7,7 @@
         <h3><span class="sn-count">{{total_nodes}}</span> Session Nodes,
             <span class="sn-count">{{operator_list | count}}</span> operators,
             <span class="sn-count">{{contributor_list | count}}</span> contributors,
-            and <span class="sn-count">{{total_staked | cash(tag_name='Network Token', zero='?', formatted=true, decimals=2)}}</span> total staked.</h3>
+            and <span class="sn-count">{{total_staked | cash(zero='?', formatted=true, decimals=2)}}</span> total staked.</h3>
 
         <h2 style="margin-bottom: 0px" id="service-node-operators">Session Node Operators <span class="sn-count">({{operator_list | count}})</span></h2>
         <div class="TitleDivider sn-awaiting"></div>

--- a/templates/tx.html
+++ b/templates/tx.html
@@ -179,7 +179,7 @@ This tx does not includes a vote from this testing session node (only 7 votes ar
             {%if tx.extra.sn_registration.contributors[0].portion == 1000000%}N/A (solo registration)
             {%else%}{{(tx.extra.sn_registration.fee / 10000) | chop0}}%
             {%endif%}</p>
-            <p><label>Contribution Amount:</label> {%if 'stake_amount' in tx%}{{tx.stake_amount | cash(tag_name='Network Token')}}{%else%}???{%endif%}</p>
+            <p><label>Contribution Amount:</label> {%if 'stake_amount' in tx%}{{tx.stake_amount | cash}}{%else%}???{%endif%}</p>
             {%if 'expiry' in tx.extra.sn_registration%}
               <p><label>Expiration:</label> {{tx.extra.sn_registration.expiry | from_timestamp | format_datetime}} ({{tx.extra.sn_registration.expiry}}),
               or {{(tx.extra.sn_registration.expiry|from_timestamp - server.datetime) | reltime}}</p>


### PR DESCRIPTION
- Remove the OXEN hack which zeroed out the string. This was a temporary change for some other requirements that is no longer needed. There are cash tags that explicitly specify 'OXEN' that will be preserved.

- Convert some hardcoded templated tags to use the 'cash' function